### PR TITLE
chore: Remove unused READ_MEDIA_IMAGES and READ_MEDIA_VIDEO permissions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,9 +55,7 @@
             </feature>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-            <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-            <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
           <provider

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -226,19 +226,27 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         ArrayList<String> permissions = new ArrayList<>();
 
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            /**
+             * Android API 33 and higher not able to require permissions for media types using READ_MEDIA_*.
+             * 
+             * See: https://support.google.com/googleplay/android-developer/answer/13986130?sjid=10655924996755721992-SA
+             * Also: https://github.com/apache/cordova-plugin-camera/issues/866
+             */
             // Android API 33 and higher
-            switch (mediaType) {
-                case PICTURE:
-                    permissions.add(Manifest.permission.READ_MEDIA_IMAGES);
-                    break;
-                case VIDEO:
-                    permissions.add(Manifest.permission.READ_MEDIA_VIDEO);
-                    break;
-                default:
-                    permissions.add(Manifest.permission.READ_MEDIA_IMAGES);
-                    permissions.add(Manifest.permission.READ_MEDIA_VIDEO);
-                    break;
-            }
+            // switch (mediaType) {
+            //     case PICTURE:
+            //         permissions.add(Manifest.permission.READ_MEDIA_IMAGES);
+            //         break;
+            //     case VIDEO:
+            //         permissions.add(Manifest.permission.READ_MEDIA_VIDEO);
+            //         break;
+            //     default:
+            //         permissions.add(Manifest.permission.READ_MEDIA_IMAGES);
+            //         permissions.add(Manifest.permission.READ_MEDIA_VIDEO);
+            //         break;
+            // }
+            
+            LOG.d(LOG_TAG, "Not able to require permissions for media types using READ_MEDIA_*.");
         } else {
             // Android API 32 or lower
             permissions.add(Manifest.permission.READ_EXTERNAL_STORAGE);


### PR DESCRIPTION
### Platforms affected
Android

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Due to [new Google policy](https://support.google.com/googleplay/android-developer/answer/13986130). 

The issue is that they don't want to use theses permissions anymore. 

I read a [big discussion](https://github.com/apache/cordova-plugin-camera/issues/866) created on the plugin about these updates. 

### Description
<!-- Describe your changes in detail -->
I removed all requests for the `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` permissions. These permissions have also been removed from the `plugin.xml` file. After running the app, I confirmed that the permissions were missing from our `AndroidManifest.xml` file, and everything is functioning smoothly.

I followed the steps outlined in [this comment](https://github.com/apache/cordova-plugin-camera/issues/866#issuecomment-2210649886). From what I read, this approach should be effective. Additionally, we use the `DATA_URL`, which is another way to avoid using permissions that Google doesn't want us to use 😆
